### PR TITLE
Adds condition to post build cleanup event, to run only if built on Windows.

### DIFF
--- a/Eco.EM.Framework/Eco.EM.Framework.csproj
+++ b/Eco.EM.Framework/Eco.EM.Framework.csproj
@@ -21,7 +21,7 @@
     <OutputPath>..\bin\9.6\Framework\</OutputPath>
   </PropertyGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT'">
     <Exec Command="cd $(TargetDir)&#xD;&#xA;del *.config&#xD;&#xA;del *.json&#xD;&#xA;del A*&#xD;&#xA;del B*&#xD;&#xA;del C*&#xD;&#xA;del D*&#xD;&#xA;del F*&#xD;&#xA;del G*&#xD;&#xA;del H*&#xD;&#xA;del I*&#xD;&#xA;del J*&#xD;&#xA;del K*&#xD;&#xA;del L*&#xD;&#xA;del M*&#xD;&#xA;del N*&#xD;&#xA;del O*&#xD;&#xA;del P*&#xD;&#xA;del Q*&#xD;&#xA;del R*&#xD;&#xA;del S*&#xD;&#xA;del T*&#xD;&#xA;del U*&#xD;&#xA;del V*&#xD;&#xA;del W*&#xD;&#xA;del X*&#xD;&#xA;del Y*&#xD;&#xA;del Z*&#xD;&#xA;del Eco.Core.dll&#xD;&#xA;del Eco.Gameplay.dll&#xD;&#xA;del Eco.Modkit.dll&#xD;&#xA;del Eco.Mods.dll&#xD;&#xA;del Eco.Networking.ENet.dll&#xD;&#xA;del Eco.Plugins.dll&#xD;&#xA;del Eco.Shared.dll&#xD;&#xA;del Eco.Simulation.dll&#xD;&#xA;del Eco.Stats.dll&#xD;&#xA;del Eco.Tests.dll&#xD;&#xA;del Eco.WebServer.dll&#xD;&#xA;del Eco.WindowsForms.dll&#xD;&#xA;del Eco.World.dll&#xD;&#xA;del Eco.WorldGenerator.dll" />
   </Target>
 


### PR DESCRIPTION
Adds condition to post build cleanup event, so it is only performed when build under Windows ecosystem.

**Public Release Notes:**
Not applicable.

**Additional Internal Details:**
*As exception*, requesting to merge it into main, as per change to the project file.

**Screenshots and videos**


**Related Issues:**
Fixes problem with runners that are hosted under Linux, as they fail trying to execute windows commands on post build cleanup event.

**Teamwork**
Names of anyone who helped significantly with this PR:

**Checklist:**
- [x] All touched code has comments matching our standard: https://github.com/StrangeLoopGames/Eco/wiki/Code-and-Comment-Guide

When fixing a regression, these are required:
- Link URL of the PR that broke it:
- [ ] Regression report (explain how and why it happened):
- [ ] Describe over fix applied (required for regressions, see [here](https://github.com/StrangeLoopGames/Eco/wiki/Strange-Loop-Coding-Principles)):



*Code review guide: https://github.com/StrangeLoopGames/Eco/wiki/Code-Review-Guide*
