### PR TITLE
Implements BackgroundTask class to handle timer based background routines.

### DIFF
--- a/Eco.EM.Framework/GroupsSystem/GroupsManager.cs
+++ b/Eco.EM.Framework/GroupsSystem/GroupsManager.cs
@@ -12,6 +12,7 @@ using Eco.WorldGenerator;
 using Eco.EM.Framework.Plugins;
 using System;
 using System.Threading.Tasks;
+using Eco.EM.Framework.Helpers;
 
 namespace Eco.EM.Framework.Groups
 {
@@ -20,7 +21,11 @@ namespace Eco.EM.Framework.Groups
         internal const string _dataFile = "ElixrMods-GroupsData.json";
         internal const string _dataBackupFile = "ElixrMods-GroupsData-Bakup.json";
         internal const string _subPath = "/EM/Groups";
-        public Timer Timer;
+
+        //Declaring the background task to periodically check for new admins added since server has been started.
+        //Proposing the naming pattern for ids: ActionName_BackgroundTask and for actions to do methods: ActionName_BackgroundTaskRoutine
+        //Lowering the time to 5 seconds from previously existing 10 seconds.
+        public BackgroundTask AdminChecker_BackgroundTask = new(TimeSpan.FromMilliseconds(5000));
 
         public static GroupsData Data { get; internal set; }
         public static GroupsData DataBackup { get; internal set; }
@@ -121,10 +126,11 @@ namespace Eco.EM.Framework.Groups
                 }
             });
 
-            Timer = new(Timer_tick, null, 10000, 10000);
+            //Starting the background task and passing the method with the backgound task routine.
+            AdminChecker_BackgroundTask.Start(AdminChecker_BackgroundTaskRoutine);
         }
 
-        static void Timer_tick(object state)
+        void AdminChecker_BackgroundTaskRoutine()
         {
             var users = PlayerUtils.Users;
             lock (Data.AllUsers)
@@ -171,10 +177,13 @@ namespace Eco.EM.Framework.Groups
 
         public string GetCategory() => "Elixr Mods";
 
-        public Task ShutdownAsync()
+        //We can add backgorund task here to ensure they are cancelled and disposed of on shutdown.
+        //Not required on simple tasks, but if some more complex routine is present it is always safer.
+        public async Task ShutdownAsync()
         {
             SaveData();
-            return Task.CompletedTask;
+            await AdminChecker_BackgroundTask.StopAsync();
+            await Task.CompletedTask;
         }
     }
 

--- a/Eco.EM.Framework/Helpers/BackgroundTask.cs
+++ b/Eco.EM.Framework/Helpers/BackgroundTask.cs
@@ -1,0 +1,60 @@
+﻿//Proposed by nidaren on 20-Sep-2022
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+#nullable enable
+
+namespace Eco.EM.Framework.Helpers
+{
+    /// <summary>
+    /// Provides a background task, based on a new PeriodicTimer available in net6, also takes into account execution time of the routine method.
+    /// It can be stopped, started, awaited, cancelled and protects against spawning a new task, when old one is still running.
+    /// </summary>
+    public class BackgroundTask
+    {
+        private Task? _timerTask;
+        private readonly PeriodicTimer _timer;
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+        public BackgroundTask(TimeSpan interval)
+        {
+            _timer = new PeriodicTimer(interval);
+        }
+
+        public void Start(Action routineToDo)
+        {
+            _timerTask = DoWorkAsync(routineToDo);
+        }
+
+        private async Task DoWorkAsync(Action routineToDo)
+        {
+            try
+            {
+                while (await _timer.WaitForNextTickAsync(_cancellationTokenSource.Token))
+                {
+                    routineToDo();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+
+            }
+        }
+
+        public async Task StopAsync()
+        {
+            if (_timerTask is null)
+            {
+                return;
+            }
+
+            _cancellationTokenSource.Cancel();
+            await _timerTask;
+            _cancellationTokenSource.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
**Public Release Notes:**
Adds BackgroundTask class to handle timer based background routines.
Lowers periodic checker for changes in Admins' list to 5 seconds.

**Additional Internal Details:**

I would like to propose a new way to handle timer based tasks, we might want to run in the background.

The idea was born from trying to replace periodic timer that checks for changes in Admins on the server _(until SLG implements the event or any other way to let us know the change occurred)_, with a solution that would allow:

- cancellation of the task;
- take into account execution time of the task;
- not spawn the new task if the old one is still running;
- starting and stopping the task;

To achieve this, I have decided to use new `PeriodicTimer` available for us in net6.

I have placed `BackgroundTask` class under `Helpers` - please do let me know if this is not an appropriate place, or it should be placed differently.

I would like to also propose naming convention:

- for background task: **ActionName_BackgroundTask** i.e. _AdminChecker_BackgroundTask_
- for background routine (tasks to be performed): **ActionName_BackgroundTaskRoutine** i.e. _AdminChecker_BackgroundTaskRoutine_

```cs
{
    /// <summary>
    /// Provides a background task, based on a new PeriodicTimer available in net6, also takes into account execution time of the routine method.
    /// It can be stopped, started, awaited, cancelled and protects against spawning a new task, when old one is still running.
    /// </summary>
    public class BackgroundTask
    {
        private Task? _timerTask;
        private readonly PeriodicTimer _timer;
        private readonly CancellationTokenSource _cancellationTokenSource = new();

        public BackgroundTask(TimeSpan interval)
        {
            _timer = new PeriodicTimer(interval);
        }

        public void Start(Action routineToDo)
        {
            _timerTask = DoWorkAsync(routineToDo);
        }

        private async Task DoWorkAsync(Action routineToDo)
        {
            try
            {
                while (await _timer.WaitForNextTickAsync(_cancellationTokenSource.Token))
                {
                    routineToDo();
                }
            }
            catch (OperationCanceledException)
            {
                //we could add logging here, but I think it is not needed, as cancellation is expected by the catch block.
                // this is also very lightweight approach.
            }
        }

        public async Task StopAsync()
        {
            if (_timerTask is null)
            {
                return;
            }

            _cancellationTokenSource.Cancel();
            await _timerTask;
            _cancellationTokenSource.Dispose();
        }
    }
}
```
and implementation on the `GroupsManager `class, I simply used the same place where old timer was implemented before:

```cs
public BackgroundTask AdminChecker_BackgroundTask = new(TimeSpan.FromMilliseconds(5000));
AdminChecker_BackgroundTask.Start(AdminChecker_BackgroundTaskRoutine);
```

The routine to do method was only changed in signature, the actions are the same as made by Kye:

```cs
void AdminChecker_BackgroundTaskRoutine()
        {
            var users = PlayerUtils.Users;
            lock (Data.AllUsers)
            {
                foreach (var u in users)
                {
                    var agroup = Data.GetorAddGroup("admin");

                    if (!u.IsAdmin && agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId || entry.SlgID == u.SlgId))
                    {
                        agroup.RemoveUser(u);
                        SaveData();
                    }

                    if (u.IsAdmin && !agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId || entry.SlgID == u.SlgId))
                    {
                        agroup.AddUser(u);
                        SaveData();
                    }
                }
            }
        }
```
In the end modified method required by the `IShutdownablePlugin` interface so we can add the running background tasks we want to stop. Not needed for simple tasks but might come useful if someone will some more logic heavy task.

```cs
    //We can add backgorund task here to ensure they are cancelled and disposed of on shutdown.
    //Not required on simple tasks, but if some more complex routine is present it is always safer.
    public async Task ShutdownAsync()
    {
       SaveData();
       await AdminChecker_BackgroundTask.StopAsync();
       await Task.CompletedTask;
    }
```
**Screenshots and videos**


**Related Issues:**

**Teamwork**
Names of anyone who helped significantly with this PR:

**Checklist:**
- [x] Code tested on server.
- [x] All touched code has comments matching our standard: https://github.com/StrangeLoopGames/Eco/wiki/Code-and-Comment-Guide

When fixing a regression, these are required:
- Link URL of the PR that broke it:
- [x] Regression report (explain how and why it happened):
- [x] Describe over fix applied (required for regressions, see [here](https://github.com/StrangeLoopGames/Eco/wiki/Strange-Loop-Coding-Principles)):

*Code review guide: https://github.com/StrangeLoopGames/Eco/wiki/Code-Review-Guide*
