### PR TITLE
Fixes logic in regards to finding and returning boolean values, when …

### DIFF
--- a/Eco.EM.Framework/GroupsSystem/GroupsData.cs
+++ b/Eco.EM.Framework/GroupsSystem/GroupsData.cs
@@ -54,10 +54,8 @@ namespace Eco.EM.Framework.Groups
         }
 
         public SimpleGroupUser GetGroupUser(User user) =>
-            
-            AllUsers.FirstOrDefault(entry => entry.Name == user.Name
-            || (entry.Name == user.Name && entry.SlgID == user.SlgId)
-            || (entry.Name == user.Name && entry.SteamID == user.SteamId));
+
+            AllUsers.FirstOrDefault(entry => entry.Name == user.Name && (entry.SlgID == user.SlgId || entry.SteamID == user.SteamId));
 
         public SimpleGroupUser GetGroupUser(IChatClient chatClient)
         {

--- a/Eco.EM.Framework/GroupsSystem/GroupsData.cs
+++ b/Eco.EM.Framework/GroupsSystem/GroupsData.cs
@@ -53,10 +53,11 @@ namespace Eco.EM.Framework.Groups
             return Groups.Remove(group);
         }
 
-        public SimpleGroupUser GetGroupUser(User user)
-        {
-            return AllUsers.FirstOrDefault(entry => entry.Name == user.Name || entry.SlgID == user.SlgId || entry.SteamID == user.SteamId);
-        }
+        public SimpleGroupUser GetGroupUser(User user) =>
+            
+            AllUsers.FirstOrDefault(entry => entry.Name == user.Name
+            || (entry.Name == user.Name && entry.SlgID == user.SlgId)
+            || (entry.Name == user.Name && entry.SteamID == user.SteamId));
 
         public SimpleGroupUser GetGroupUser(IChatClient chatClient)
         {

--- a/Eco.EM.Framework/GroupsSystem/GroupsManager.cs
+++ b/Eco.EM.Framework/GroupsSystem/GroupsManager.cs
@@ -13,7 +13,6 @@ using Eco.EM.Framework.Plugins;
 using System;
 using System.Threading.Tasks;
 using Eco.EM.Framework.Helpers;
-using Eco.ModKit.Internal;
 
 namespace Eco.EM.Framework.Groups
 {
@@ -79,9 +78,7 @@ namespace Eco.EM.Framework.Groups
             {
                 lock (Data.AllUsers)
                 {
-                    if (!Data.AllUsers.Any(entry => entry.Name == usr.Name 
-                    || entry.Name == usr.Name && entry.SteamID == usr.SteamId 
-                    || entry.Name == usr.Name && entry.SlgID == usr.SlgId))
+                    if (!Data.AllUsers.Any(entry => entry.Name == usr.Name && (entry.SlgID == usr.SlgId || entry.SteamID == usr.SteamId)))
                     {
                         Data.AllUsers.Add(new SimpleGroupUser(usr.Name, usr.SlgId ?? "", usr.SteamId ?? ""));
                         SaveData();
@@ -95,9 +92,7 @@ namespace Eco.EM.Framework.Groups
                     else
                         group = Data.GetorAddGroup("default");
 
-                    if (!group.GroupUsers.Any(entry => entry.Name == usr.Name 
-                    || entry.Name == usr.Name && entry.SteamID == usr.SteamId 
-                    || entry.Name == usr.Name && entry.SlgID == usr.SlgId))
+                    if (!group.GroupUsers.Any(entry => entry.Name == usr.Name && (entry.SlgID == usr.SlgId || entry.SteamID == usr.SteamId)))
                     {
                         group.AddUser(usr);
                         SaveData();
@@ -109,7 +104,7 @@ namespace Eco.EM.Framework.Groups
             {
                 lock (Data.AllUsers)
                 {
-                    if (!Data.AllUsers.Any(entry => entry.Name == u.Name || entry.SteamID == u.SteamId || entry.SlgID == u.SlgId))
+                    if (!Data.AllUsers.Any(entry => entry.Name == u.Name && (entry.SlgID == u.SlgId || entry.SteamID == u.SteamId)))
                     {
                         Data.AllUsers.Add(new SimpleGroupUser(u.Name, u.SlgId ?? "", u.SteamId ?? ""));
                         SaveData();
@@ -123,7 +118,7 @@ namespace Eco.EM.Framework.Groups
                     else
                         group = Data.GetorAddGroup("default");
 
-                    if (!group.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId || entry.SlgID == u.SlgId))
+                    if (!group.GroupUsers.Any(entry => entry.Name == u.Name && (entry.SlgID == u.SlgId || entry.SteamID == u.SteamId)))
                     {
                         group.AddUser(u);
                         SaveData();
@@ -144,15 +139,13 @@ namespace Eco.EM.Framework.Groups
                 {
                     var agroup = Data.GetorAddGroup("admin");
 
-                    if (!u.IsAdmin && agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId 
-                    || entry.Name == u.Name && entry.SlgID == u.SlgId))
+                    if (!u.IsAdmin && agroup.GroupUsers.Any(entry => entry.Name == u.Name && (entry.SlgID == u.SlgId || entry.SteamID == u.SteamId)))
                     {
                         agroup.RemoveUser(u);
                         SaveData();
                     }
 
-                    if (u.IsAdmin && !agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId 
-                    || entry.Name == u.Name && entry.SlgID == u.SlgId))
+                    if (u.IsAdmin && !agroup.GroupUsers.Any(entry => entry.Name == u.Name && (entry.SlgID == u.SlgId || entry.SteamID == u.SteamId)))
                     {
                         agroup.AddUser(u);
                         SaveData();

--- a/Eco.EM.Framework/GroupsSystem/GroupsManager.cs
+++ b/Eco.EM.Framework/GroupsSystem/GroupsManager.cs
@@ -13,6 +13,7 @@ using Eco.EM.Framework.Plugins;
 using System;
 using System.Threading.Tasks;
 using Eco.EM.Framework.Helpers;
+using Eco.ModKit.Internal;
 
 namespace Eco.EM.Framework.Groups
 {
@@ -78,7 +79,9 @@ namespace Eco.EM.Framework.Groups
             {
                 lock (Data.AllUsers)
                 {
-                    if (!Data.AllUsers.Any(entry => entry.Name == usr.Name || entry.SteamID == usr.SteamId || entry.SlgID == usr.SlgId))
+                    if (!Data.AllUsers.Any(entry => entry.Name == usr.Name 
+                    || entry.Name == usr.Name && entry.SteamID == usr.SteamId 
+                    || entry.Name == usr.Name && entry.SlgID == usr.SlgId))
                     {
                         Data.AllUsers.Add(new SimpleGroupUser(usr.Name, usr.SlgId ?? "", usr.SteamId ?? ""));
                         SaveData();
@@ -92,7 +95,9 @@ namespace Eco.EM.Framework.Groups
                     else
                         group = Data.GetorAddGroup("default");
 
-                    if (!group.GroupUsers.Any(entry => entry.Name == usr.Name || entry.SteamID == usr.SteamId || entry.SlgID == usr.SlgId))
+                    if (!group.GroupUsers.Any(entry => entry.Name == usr.Name 
+                    || entry.Name == usr.Name && entry.SteamID == usr.SteamId 
+                    || entry.Name == usr.Name && entry.SlgID == usr.SlgId))
                     {
                         group.AddUser(usr);
                         SaveData();
@@ -139,13 +144,15 @@ namespace Eco.EM.Framework.Groups
                 {
                     var agroup = Data.GetorAddGroup("admin");
 
-                    if (!u.IsAdmin && agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId || entry.SlgID == u.SlgId))
+                    if (!u.IsAdmin && agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId 
+                    || entry.Name == u.Name && entry.SlgID == u.SlgId))
                     {
                         agroup.RemoveUser(u);
                         SaveData();
                     }
 
-                    if (u.IsAdmin && !agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId || entry.SlgID == u.SlgId))
+                    if (u.IsAdmin && !agroup.GroupUsers.Any(entry => entry.Name == u.Name && entry.SteamID == u.SteamId 
+                    || entry.Name == u.Name && entry.SlgID == u.SlgId))
                     {
                         agroup.AddUser(u);
                         SaveData();


### PR DESCRIPTION
The description as well as replication steps are described in #21, so I won't be copy-pasting them here.

**Public Release Notes:**
Fixes issue with various  checkers within logic, falsely returning that user exists in the the target group, if there is a different user with no SlgId or SteamId.

**Additional Internal Details:**
Fixes #21 

Fix is implemented in the following portions of the code:

```cs
public SimpleGroupUser GetGroupUser(User user)
        {
            // For example this will return any user that has empty SlgId,
            return AllUsers.FirstOrDefault(entry => entry.Name == user.Name || entry.SlgID == user.SlgId || entry.SteamID == user.SteamId);
        }
```

called here:
```cs
public bool AddUser(User user)
        // This won't add any more users with no SlgId for example, if such users are already present in the target group.
        {
            var sgu = GroupsManager.Data.GetGroupUser(user);
            if (sgu != null)
                return AddUser(sgu);
            else
                return false;
        }
```

The above are fixed by adding additional condition to return the result properly:

```cs
public SimpleGroupUser GetGroupUser(User user) =>
            
            AllUsers.FirstOrDefault(entry => entry.Name == user.Name
            || (entry.Name == user.Name && entry.SlgID == user.SlgId)
            || (entry.Name == user.Name && entry.SteamID == user.SteamId));
```

`Initialize` logic on `GroupManager` is fixed as well:

```cs
lock (Data.AllUsers)
                {
                    if (!Data.AllUsers.Any(entry => entry.Name == usr.Name 
                    || entry.Name == usr.Name && entry.SteamID == usr.SteamId 
                    || entry.Name == usr.Name && entry.SlgID == usr.SlgId))
                    {
                        Data.AllUsers.Add(new SimpleGroupUser(usr.Name, usr.SlgId ?? "", usr.SteamId ?? ""));
                        SaveData();
                    }

                    /* Only implement if we think this is necessary , it will basically disable server configs for TP's, Homes and Warps*/
                    Group group;

                    if (usr.IsAdminOrDev)
                        group = Data.GetorAddGroup("admin");
                    else
                        group = Data.GetorAddGroup("default");

                    if (!group.GroupUsers.Any(entry => entry.Name == usr.Name 
                    || entry.Name == usr.Name && entry.SteamID == usr.SteamId 
                    || entry.Name == usr.Name && entry.SlgID == usr.SlgId))
                    {
                        group.AddUser(usr);
                        SaveData();
                    }
                }             
```

**Screenshots and videos**


**Related Issues:**

**Teamwork**
Names of anyone who helped significantly with this PR:

**Checklist:**
- [x] Changes tested on server.
- [x] All touched code has comments matching our standard: https://github.com/StrangeLoopGames/Eco/wiki/Code-and-Comment-Guide

When fixing a regression, these are required:
- Link URL of the PR that broke it:
- [x] Regression report (explain how and why it happened):
- [x] Describe over fix applied (required for regressions, see [here](https://github.com/StrangeLoopGames/Eco/wiki/Strange-Loop-Coding-Principles)):



*Code review guide: https://github.com/StrangeLoopGames/Eco/wiki/Code-Review-Guide*
