### PR TITLE
Moved EMCustoms to its own plugin

### DIFF
--- a/Eco.EM.Framework/Config/EMConfigureConfig.cs
+++ b/Eco.EM.Framework/Config/EMConfigureConfig.cs
@@ -68,10 +68,6 @@ namespace Eco.EM.Framework.Resolvers
         [LocDescription("Vehicle Configuration Values by modules. ANY change to this list will require a server restart to take effect.")]
         [LocDisplayName("Vehicle Configuration Values")]
         public SerializedSynchronizedCollection<VehicleModel> EMVehicles { get; set; } = new();
-
-        //Added Customs to the config file
-        [LocDescription("Custom Configuration Values by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Custom Configuration Values")]
-        public SerializedSynchronizedCollection<CustomsModel> EMCustoms { get; set; } = new();
+        //Moved EMCustoms into EMCustoomsConfig
     }
 }

--- a/Eco.EM.Framework/Config/EMConfigureConfig.cs
+++ b/Eco.EM.Framework/Config/EMConfigureConfig.cs
@@ -1,5 +1,4 @@
-﻿using Eco.Core.Utils;
-using Eco.Shared.Localization;
+﻿using Eco.Shared.Localization;
 
 namespace Eco.EM.Framework.Resolvers
 {
@@ -36,38 +35,5 @@ namespace Eco.EM.Framework.Resolvers
         [LocDisplayName("Enable Lucky Strike For All")]
         [LocDescription("Enables Lucky Strike as a Default Thing, which means the talent is no longer needed, Requires Manual Removal after Disable. Requires Server Restart.")]
         public bool EnableGlobalLuckyStrike { get; set; } = false;
-
-        [LocDescription("Recipes loaded by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Recipes")]
-        public SerializedSynchronizedCollection<RecipeModel> EMRecipes { get; set; } = new();
-
-        [LocDescription("EM Link radius loaded by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Link Distances")]
-        public SerializedSynchronizedCollection<LinkModel> EMLinkDistances { get; set; } = new();
-
-        [LocDescription("Stack sizes by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Stack Sizes")]
-        public SerializedSynchronizedCollection<StackSizeModel> EMStackSizes { get; set; } = new();
-
-        [LocDescription("Storage slots by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Storage Slots")]
-        public SerializedSynchronizedCollection<StorageSlotModel> EMStorageSlots { get; set; } = new();
-
-        [LocDescription("Item weight by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Item Weight")]
-        public SerializedSynchronizedCollection<ItemWeightModel> EMItemWeight { get; set; } = new();
-
-        [LocDescription("Food Item Values by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Food Items")]
-        public SerializedSynchronizedCollection<FoodItemModel> EMFoodItem { get; set; } = new();
-
-        [LocDescription("Home Furnishing Values by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Home Furnishing Values")]
-        public SerializedSynchronizedCollection<HousingModel> EMHousingValue { get; set; } = new();
-
-        [LocDescription("Vehicle Configuration Values by modules. ANY change to this list will require a server restart to take effect.")]
-        [LocDisplayName("Vehicle Configuration Values")]
-        public SerializedSynchronizedCollection<VehicleModel> EMVehicles { get; set; } = new();
-        //Moved EMCustoms into EMCustoomsConfig
     }
 }

--- a/Eco.EM.Framework/Config/EMCustomsConfig.cs
+++ b/Eco.EM.Framework/Config/EMCustomsConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMCustomsConfig
+    {
+        [LocDescription("Custom Configuration Values by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Custom Configuration Values")]
+        public SerializedSynchronizedCollection<CustomsModel> EMCustoms { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMFoodItemConfig.cs
+++ b/Eco.EM.Framework/Config/EMFoodItemConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMFoodItemConfig
+    {
+        [LocDescription("Food Item Values by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Food Items")]
+        public SerializedSynchronizedCollection<FoodItemModel> EMFoodItem { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMHousingValueConfig.cs
+++ b/Eco.EM.Framework/Config/EMHousingValueConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMHousingValueConfig
+    {
+        [LocDescription("Home Furnishing Values by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Home Furnishing Values")]
+        public SerializedSynchronizedCollection<HousingModel> EMHousingValue { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMItemWeightConfig.cs
+++ b/Eco.EM.Framework/Config/EMItemWeightConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMItemWeightConfig
+    {
+        [LocDescription("Item weight by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Item Weight")]
+        public SerializedSynchronizedCollection<ItemWeightModel> EMItemWeight { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMLinkDistancesConfig.cs
+++ b/Eco.EM.Framework/Config/EMLinkDistancesConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMLinkDistancesConfig
+    {
+        [LocDescription("EM Link radius loaded by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Link Distances")]
+        public SerializedSynchronizedCollection<LinkModel> EMLinkDistances { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMRecipesConfig.cs
+++ b/Eco.EM.Framework/Config/EMRecipesConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMRecipesConfig
+    {
+        [LocDescription("Recipes loaded by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Recipes")]
+        public SerializedSynchronizedCollection<RecipeModel> EMRecipes { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMStackSizesConfig.cs
+++ b/Eco.EM.Framework/Config/EMStackSizesConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMStackSizesConfig
+    {
+        [LocDescription("Stack sizes by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Stack Sizes")]
+        public SerializedSynchronizedCollection<StackSizeModel> EMStackSizes { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMStorageSlotsConfig.cs
+++ b/Eco.EM.Framework/Config/EMStorageSlotsConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMStorageSlotsConfig
+    {
+        [LocDescription("Storage slots by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Storage Slots")]
+        public SerializedSynchronizedCollection<StorageSlotModel> EMStorageSlots { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Config/EMVehiclesConfig.cs
+++ b/Eco.EM.Framework/Config/EMVehiclesConfig.cs
@@ -1,0 +1,12 @@
+﻿using Eco.Core.Utils;
+using Eco.Shared.Localization;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    public class EMVehiclesConfig
+    {
+        [LocDescription("Vehicle Configuration Values by modules. ANY change to this list will require a server restart to take effect.")]
+        [LocDisplayName("Vehicle Configuration Values")]
+        public SerializedSynchronizedCollection<VehicleModel> EMVehicles { get; set; } = new();
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMConfigurePlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMConfigurePlugin.cs
@@ -2,18 +2,12 @@
 using Eco.Core.Plugins.Interfaces;
 using Eco.Core.Utils;
 using Eco.EM.Framework.Utils;
-using Eco.Gameplay.Objects;
 using Eco.Gameplay.Players;
-using Eco.Gameplay.Systems.Chat;
 using Eco.Gameplay.Systems.Messaging.Chat.Commands;
-using Eco.Mods.TechTree;
-using Eco.Shared.Items;
 using Eco.Shared.Localization;
 using Eco.Shared.Utils;
-using Eco.Simulation.WorldLayers.History;
-using System;
 using System.IO;
-using System.Reflection;
+// Removed unused references
 
 namespace Eco.EM.Framework.Resolvers
 {
@@ -78,11 +72,10 @@ namespace Eco.EM.Framework.Resolvers
             WritingUtils.WriteFromEmbeddedResource("Eco.EM.Framework.SpecialItems", "largelumberStockpile.txt", agdir, ".cs", specificFileName: "LargeLumberStockpileObject.override");
 
         }
-
+        // Moved EMCustomsResolver.Obj.Initalize() into EMCustomsPlugin.PostInitialize()
         public static void PostInitialize()
         {
             EMHousingResolver.Obj.Initialize();
-            EMCustomsResolver.Obj.Initialize(); //Added CustomsResolver initalization to PostInitalize
             EMStackSizeResolver.Initialize();
             EMItemWeightResolver.Initialize();
 

--- a/Eco.EM.Framework/Plugins/EMConfigurePlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMConfigurePlugin.cs
@@ -33,13 +33,9 @@ namespace Eco.EM.Framework.Resolvers
 
         public static void Initialize()
         {
-            EMRecipeResolver.Obj.Initialize();
-            EMLinkRadiusResolver.Obj.Initialize();
-            EMStorageSlotResolver.Obj.Initialize();
-            EMFoodItemResolver.Obj.Initialize();
-            EMVehicleResolver.Obj.Initialize();
             RunStockpileResolver();
             RunLuckyStrikeResolver();
+            config.SaveAsync();
         }
 
         private static void RunLuckyStrikeResolver()
@@ -71,15 +67,6 @@ namespace Eco.EM.Framework.Resolvers
             WritingUtils.WriteFromEmbeddedResource("Eco.EM.Framework.SpecialItems", "lumberStockpile.txt", agdir, ".cs", specificFileName: "LumberStockpileObject.override");
             WritingUtils.WriteFromEmbeddedResource("Eco.EM.Framework.SpecialItems", "largelumberStockpile.txt", agdir, ".cs", specificFileName: "LargeLumberStockpileObject.override");
 
-        }
-        // Moved EMCustomsResolver.Obj.Initalize() into EMCustomsPlugin.PostInitialize()
-        public static void PostInitialize()
-        {
-            EMHousingResolver.Obj.Initialize();
-            EMStackSizeResolver.Initialize();
-            EMItemWeightResolver.Initialize();
-
-            config.SaveAsync();
         }
 
         public override string ToString() => Localizer.DoStr("EM Configure");

--- a/Eco.EM.Framework/Plugins/EMCustomsPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMCustomsPlugin.cs
@@ -8,7 +8,6 @@ using Eco.Shared.Utils;
 
 namespace Eco.EM.Framework.Resolvers
 {
-    /// <summary>This is the EMConfigurePlugin with some minor edits</summary>
     [LocDisplayName("EM Customs Plugin")]
     [ChatCommandHandler]
     [Priority(200)]
@@ -21,7 +20,7 @@ namespace Eco.EM.Framework.Resolvers
 
         public object GetEditObject() => config.Config;
         public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
-        public string GetStatus() => $"Loaded EM Customs - Customs Used: {EMCustomsResolver.Obj.LoadedCustomsOverrides?.Count: 0}";
+        public string GetStatus() => $"Loaded EM Customs - Overrides Used: {EMCustomsResolver.Obj.LoadedCustomsOverrides?.Count: 0}";
 
         static EMCustomsPlugin()
         {
@@ -40,7 +39,7 @@ namespace Eco.EM.Framework.Resolvers
         public static void GenerateEmCustoms(User user)
         {
             config.SaveAsync();
-            ChatBase.ChatBaseExtended.CBOkBox("Customs File Generated, you can find it in: Configs/EMCustoms.eco", user);
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/EMCustoms.eco", user);
         }
 
         [ChatCommand("Force the Rebuild of the EMCustoms.eco File", "fbuild-emcustoms", ChatAuthorizationLevel.Admin)]

--- a/Eco.EM.Framework/Plugins/EMCustomsPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMCustomsPlugin.cs
@@ -1,0 +1,56 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    /// <summary>This is the EMConfigurePlugin with some minor edits</summary>
+    [LocDisplayName("EM Customs Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMCustomsPlugin : Singleton<EMCustomsPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMCustomsConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMCustomsConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => $"Loaded EM Customs - Customs Used: {EMCustomsResolver.Obj.LoadedCustomsOverrides?.Count: 0}";
+
+        static EMCustomsPlugin()
+        {
+            config = new PluginConfig<EMCustomsConfig>("EMCustoms");
+        }
+
+        public static void PostInitialize()
+        {
+            EMCustomsResolver.Obj.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Customs");
+
+        [ChatCommand("Generates The EMCustoms.eco File for people who have headless server", "gen-emcustoms", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmCustoms(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Customs File Generated, you can find it in: Configs/EMCustoms.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMCustoms.eco File", "fbuild-emcustoms", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmCustoms(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMCustoms.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMFoodItemPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMFoodItemPlugin.cs
@@ -1,0 +1,55 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    [LocDisplayName("EM Food Item Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMFoodItemPlugin : Singleton<EMFoodItemPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMFoodItemConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMFoodItemConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => $"Loaded EM Food Items - Overrides Used: {EMFoodItemResolver.Obj.LoadedFoodOverrides?.Count: 0}";
+
+        static EMFoodItemPlugin()
+        {
+            config = new PluginConfig<EMFoodItemConfig>("EMFoodItems");
+        }
+
+        public static void Initialize()
+        {
+            EMFoodItemResolver.Obj.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Food Items");
+
+        [ChatCommand("Generates The EMFoodItems.eco File for people who have headless server", "gen-emfoods", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmFoodItems(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Configs File Generated, you can find it in: Configs/EMFoodItems.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMFoodItems.eco File", "fbuild-emfoods", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmFoodItems(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMFoodItems.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMHousingValuePlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMHousingValuePlugin.cs
@@ -1,0 +1,55 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    [LocDisplayName("EM Housing Value Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMHousingValuePlugin : Singleton<EMHousingValuePlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMHousingValueConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMHousingValueConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => $"Loaded EM Housing Values - Overrides Used: {EMHousingResolver.Obj.LoadedHomeOverrides?.Count: 0}";
+
+        static EMHousingValuePlugin()
+        {
+            config = new PluginConfig<EMHousingValueConfig>("EMHousingValue");
+        }
+
+        public static void PostInitialize()
+        {
+            EMHousingResolver.Obj.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Housing Value");
+
+        [ChatCommand("Generates The EMHousingValue.eco File for people who have headless server", "gen-emhouse", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmHousingValues(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/EMHousingValue.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMHousingValue.eco File", "fbuild-emhouse", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmHousingValues(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMHousingValue.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMItemWeightPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMItemWeightPlugin.cs
@@ -1,0 +1,55 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    [LocDisplayName("EM Item Weight Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMItemWeightPlugin : Singleton<EMItemWeightPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMItemWeightConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMItemWeightConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => "Loaded EM Item Weights";
+
+        static EMItemWeightPlugin()
+        {
+            config = new PluginConfig<EMItemWeightConfig>("EMItemWeight");
+        }
+
+        public static void PostInitialize()
+        {
+            EMItemWeightResolver.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Item Weight");
+
+        [ChatCommand("Generates The EMItemWeight.eco File for people who have headless server", "gen-emweights", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmItemWeight(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/EMItemWeight.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMItemWeight.eco File", "fbuild-emweights", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmItemWeight(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMItemWeight.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMLinkDistancesPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMLinkDistancesPlugin.cs
@@ -1,0 +1,55 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    [LocDisplayName("EM Link Distances Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMLinkDistancesPlugin : Singleton<EMLinkDistancesPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMLinkDistancesConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMLinkDistancesConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => "Loaded EM Link Distances";
+
+        static EMLinkDistancesPlugin()
+        {
+            config = new PluginConfig<EMLinkDistancesConfig>("EMLinkDistances");
+        }
+
+        public static void Initialize()
+        {
+            EMLinkRadiusResolver.Obj.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Link Distances");
+
+        [ChatCommand("Generates The EMLinkDistances.eco File for people who have headless server", "gen-emlinks", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmLinkDistances(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/EMLinkDistances.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMLinkDistances.eco File", "fbuild-emlinks", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmLinkDistances(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMLinkDistances.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMRecipesPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMRecipesPlugin.cs
@@ -1,0 +1,55 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    [LocDisplayName("EM Recipes Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMRecipesPlugin : Singleton<EMRecipesPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMRecipesConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMRecipesConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => $"Loaded EM Recipes - Overrides Used: {EMRecipeResolver.Obj.LoadedConfigRecipes?.Count: 0}";
+
+        static EMRecipesPlugin()
+        {
+            config = new PluginConfig<EMRecipesConfig>("EMRecipes");
+        }
+
+        public static void Initialize()
+        {
+            EMRecipeResolver.Obj.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Recipes");
+
+        [ChatCommand("Generates The EMRecipes.eco File for people who have headless server", "gen-emrecipes", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmRecipes(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/EMRecipes.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMRecipes.eco File", "fbuild-emrecipes", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmRecipes(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMRecipes.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMStackSizesPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMStackSizesPlugin.cs
@@ -1,0 +1,55 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    [LocDisplayName("EM Stack Sizes Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMStackSizesPlugin : Singleton<EMStackSizesPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMStackSizesConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMStackSizesConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => "Loaded EM Stack Sizes";
+
+        static EMStackSizesPlugin()
+        {
+            config = new PluginConfig<EMStackSizesConfig>("EMStackSizes");
+        }
+
+        public static void PostInitialize()
+        {
+            EMStackSizeResolver.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Stack Sizes");
+
+        [ChatCommand("Generates The StackSizes.eco File for people who have headless server", "gen-emstacks", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmStackSizes(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/StackSizes.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMStackSizes.eco File", "fbuild-emstacks", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmStackSizes(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMStackSizes.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMStorageSlotsPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMStorageSlotsPlugin.cs
@@ -1,0 +1,56 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    /// <summary>This is the EMConfigurePlugin with some minor edits</summary>
+    [LocDisplayName("EM Storage Slots Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMStorageSlotsPlugin : Singleton<EMStorageSlotsPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMStorageSlotsConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMStorageSlotsConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => "Loaded EM Storage Slots";
+
+        static EMStorageSlotsPlugin()
+        {
+            config = new PluginConfig<EMStorageSlotsConfig>("EMStorageSlots");
+        }
+
+        public static void Initialize()
+        {
+            EMStorageSlotResolver.Obj.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Storage Slots");
+
+        [ChatCommand("Generates The EMStorageSlots.eco File for people who have headless server", "gen-emslots", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmStorageSlots(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/EMStorageSlots.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMStorageSlots.eco File", "fbuild-emslots", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmStorageSlots(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMStorageSlots.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Plugins/EMVehiclesPlugin.cs
+++ b/Eco.EM.Framework/Plugins/EMVehiclesPlugin.cs
@@ -1,0 +1,56 @@
+﻿using Eco.Core.Plugins;
+using Eco.Core.Plugins.Interfaces;
+using Eco.Core.Utils;
+using Eco.Gameplay.Players;
+using Eco.Gameplay.Systems.Messaging.Chat.Commands;
+using Eco.Shared.Localization;
+using Eco.Shared.Utils;
+
+namespace Eco.EM.Framework.Resolvers
+{
+    /// <summary>This is the EMConfigurePlugin with some minor edits</summary>
+    [LocDisplayName("EM Vehicles Plugin")]
+    [ChatCommandHandler]
+    [Priority(200)]
+    public class EMVehiclesPlugin : Singleton<EMVehiclesPlugin>, IModKitPlugin, IConfigurablePlugin, IModInit
+    {
+        private static readonly PluginConfig<EMVehiclesConfig> config;
+        public IPluginConfig PluginConfig => config;
+        public static EMVehiclesConfig Config => config.Config;
+        public ThreadSafeAction<object, string> ParamChanged { get; set; } = new ThreadSafeAction<object, string>();
+
+        public object GetEditObject() => config.Config;
+        public void OnEditObjectChanged(object o, string param) => this.SaveConfig();
+        public string GetStatus() => $"Loaded EM Vehicles - Overrides Used: {EMVehicleResolver.Obj.LoadedVehicleOverrides?.Count: 0}";
+
+        static EMVehiclesPlugin()
+        {
+            config = new PluginConfig<EMVehiclesConfig>("EMVehicles");
+        }
+
+        public static void Initialize()
+        {
+            EMVehicleResolver.Obj.Initialize();
+            config.SaveAsync();
+        }
+
+        public override string ToString() => Localizer.DoStr("EM Vehicles");
+
+        [ChatCommand("Generates The EMVehicles.eco File for people who have headless server", "gen-emvehicles", ChatAuthorizationLevel.Admin)]
+        public static void GenerateEmVehicles(User user)
+        {
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Generated, you can find it in: Configs/EMVehicles.eco", user);
+        }
+
+        [ChatCommand("Force the Rebuild of the EMVehicles.eco File", "fbuild-emvehicles", ChatAuthorizationLevel.Admin)]
+        public static void ForceRebuildEmVehicles(User user)
+        {
+            config.ResetAsync();
+            config.SaveAsync();
+            ChatBase.ChatBaseExtended.CBOkBox("Config File Reset and Re-Generated, you can find it in: Configs/EMVehicles.eco", user);
+        }
+
+        public string GetCategory() => "Elixr Mods";
+    }
+}

--- a/Eco.EM.Framework/Resolvers/CustomsResolver.cs
+++ b/Eco.EM.Framework/Resolvers/CustomsResolver.cs
@@ -37,7 +37,7 @@ namespace Eco.EM.Framework.Resolvers
             // gets configs if they exist
             try
             {
-                previousModels = EMConfigurePlugin.Config.EMCustoms;
+                previousModels = EMCustomsPlugin.Config.EMCustoms;
             }
             catch
             {
@@ -59,7 +59,7 @@ namespace Eco.EM.Framework.Resolvers
                 else newModels.Add(lModel);
             }
 
-            EMConfigurePlugin.Config.EMCustoms = newModels;
+            EMCustomsPlugin.Config.EMCustoms = newModels;
 
             // adds the models to the overrides for use by GetCustom()
             foreach (var model in newModels)

--- a/Eco.EM.Framework/Resolvers/EMFoodItemResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMFoodItemResolver.cs
@@ -99,7 +99,7 @@ namespace Eco.EM.Framework.Resolvers
         public void Initialize()
         {
             SerializedSynchronizedCollection<FoodItemModel> newModels = new();
-            var previousModels = EMConfigurePlugin.Config.EMFoodItem;
+            var previousModels = EMFoodItemPlugin.Config.EMFoodItem;
             foreach (var type in typeof(IConfigurableFoodItem).ConcreteTypes())
             {
                 System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type.TypeHandle);
@@ -118,7 +118,7 @@ namespace Eco.EM.Framework.Resolvers
                     newModels.Add(lModel);
             }
 
-            EMConfigurePlugin.Config.EMFoodItem = newModels;
+            EMFoodItemPlugin.Config.EMFoodItem = newModels;
 
             foreach (var model in newModels)
             {

--- a/Eco.EM.Framework/Resolvers/EMHousingResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMHousingResolver.cs
@@ -72,7 +72,7 @@ namespace Eco.EM.Framework.Resolvers
             var previousModels = newModels;
             try
             {
-                previousModels = EMConfigurePlugin.Config.EMHousingValue;
+                previousModels = EMHousingValuePlugin.Config.EMHousingValue;
             }
             catch
             {
@@ -107,7 +107,7 @@ namespace Eco.EM.Framework.Resolvers
                     newModels.Add(lModel);
             }
 
-            EMConfigurePlugin.Config.EMHousingValue = newModels;
+            EMHousingValuePlugin.Config.EMHousingValue = newModels;
 
             foreach (var model in newModels)
             {

--- a/Eco.EM.Framework/Resolvers/EMItemWeightResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMItemWeightResolver.cs
@@ -22,7 +22,7 @@ namespace Eco.EM.Framework.Resolvers
         // Goes through and loads new items for stack sizes into the dictionary.
         private static void BuildStackSizeList(IEnumerable<Item> locals)
         {
-            var config = EMConfigurePlugin.Config.EMItemWeight;
+            var config = EMItemWeightPlugin.Config.EMItemWeight;
             // Go through and keep items that are still referenced in the namespace
             SerializedSynchronizedCollection<ItemWeightModel> cleanList = new SerializedSynchronizedCollection<ItemWeightModel>();
             for (int i = 0; i < config.Count; i++)
@@ -41,7 +41,7 @@ namespace Eco.EM.Framework.Resolvers
                     cleanList.Add(new ItemWeightModel(i.GetType(), i.DisplayName, i.Weight, false));
             }
 
-            EMConfigurePlugin.Config.EMItemWeight = cleanList;
+            EMItemWeightPlugin.Config.EMItemWeight = cleanList;
         }
 
         // Overrides the preset stacksizes to those set in the config on load before adding newly created items
@@ -50,7 +50,7 @@ namespace Eco.EM.Framework.Resolvers
             foreach (var i in locals)
             {
                 // Check for the items in the stack size list
-                var element = EMConfigurePlugin.Config.EMItemWeight.SingleOrDefault(x => x.DisplayName == i.DisplayName);
+                var element = EMItemWeightPlugin.Config.EMItemWeight.SingleOrDefault(x => x.DisplayName == i.DisplayName);
                 if (element == null) continue;
                 var orThis = element.OverrideThis;
                 // Get the stacksize attribute and override it.

--- a/Eco.EM.Framework/Resolvers/EMLinkRadiusResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMLinkRadiusResolver.cs
@@ -36,7 +36,7 @@ namespace Eco.EM.Framework.Resolvers
         public void Initialize()
         {
             SerializedSynchronizedCollection<LinkModel> newModels = new();
-            var config = EMConfigurePlugin.Config.EMLinkDistances;
+            var config = EMLinkDistancesPlugin.Config.EMLinkDistances;
 
             foreach (var type in typeof(ILinkRadiusObject).ConcreteTypes())
             {
@@ -55,7 +55,7 @@ namespace Eco.EM.Framework.Resolvers
                     newModels.Add(lModel);
             }
 
-            EMConfigurePlugin.Config.EMLinkDistances = newModels;
+            EMLinkDistancesPlugin.Config.EMLinkDistances = newModels;
 
             foreach (var model in newModels)
             {

--- a/Eco.EM.Framework/Resolvers/EMRecipeResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMRecipeResolver.cs
@@ -316,7 +316,7 @@ namespace Eco.EM.Framework.Resolvers
         private void LoadConfigOverrides()
         {
             SerializedSynchronizedCollection<RecipeModel> newModels = new();
-            var previousModels = EMConfigurePlugin.Config.EMRecipes;
+            var previousModels = EMRecipesPlugin.Config.EMRecipes;
 
             foreach (var type in typeof(IConfigurableRecipe).ConcreteTypes())
             {
@@ -338,9 +338,9 @@ namespace Eco.EM.Framework.Resolvers
                 else
                     newModels.Add(dModel);
             }
-            EMConfigurePlugin.Config.EMRecipes = newModels;
+            EMRecipesPlugin.Config.EMRecipes = newModels;
 
-            foreach (var model in EMConfigurePlugin.Config.EMRecipes)
+            foreach (var model in EMRecipesPlugin.Config.EMRecipes)
             {
                 if (!LoadedConfigRecipes.ContainsKey(model.ModelType))
                 {

--- a/Eco.EM.Framework/Resolvers/EMStackSizeResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMStackSizeResolver.cs
@@ -23,7 +23,7 @@ namespace Eco.EM.Framework.Resolvers
         // Goes through and loads new items for stack sizes into the dictionary.
         private static void BuildStackSizeList(IEnumerable<Item> locals)
         {
-            var config = EMConfigurePlugin.Config.EMStackSizes;
+            var config = EMStackSizesPlugin.Config.EMStackSizes;
             // Go through and keep items that are still referenced in the namespace
             SerializedSynchronizedCollection<StackSizeModel> cleanList = new SerializedSynchronizedCollection<StackSizeModel>();
             for (int i = 0; i < config.Count; i++)
@@ -42,7 +42,7 @@ namespace Eco.EM.Framework.Resolvers
                     cleanList.Add(new StackSizeModel(i.GetType(), i.DisplayName, i.MaxStackSize, false));
             }
 
-            EMConfigurePlugin.Config.EMStackSizes = cleanList;
+            EMStackSizesPlugin.Config.EMStackSizes = cleanList;
         }
 
         // Overrides the preset stacksizes to those set in the config on load before adding newly created items
@@ -51,7 +51,7 @@ namespace Eco.EM.Framework.Resolvers
             foreach (var i in locals)
             {
                 // Check for the items in the stack size list
-                var element = EMConfigurePlugin.Config.EMStackSizes.SingleOrDefault(x => x.DisplayName == i.DisplayName);
+                var element = EMStackSizesPlugin.Config.EMStackSizes.SingleOrDefault(x => x.DisplayName == i.DisplayName);
                 if (element == null) continue;
                 var orThis = element.OverrideThis;
                 var forced = EMConfigurePlugin.Config.ForceSameStackSizes;

--- a/Eco.EM.Framework/Resolvers/EMStorageSlotResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMStorageSlotResolver.cs
@@ -51,7 +51,7 @@ namespace Eco.EM.Framework.Resolvers
         public void Initialize()
         {
             SerializedSynchronizedCollection<StorageSlotModel> newModels = new();
-            var config = EMConfigurePlugin.Config.EMStorageSlots;
+            var config = EMStorageSlotsPlugin.Config.EMStorageSlots;
 
             foreach (var type in typeof(IStorageSlotObject).ConcreteTypes())
             {
@@ -70,7 +70,7 @@ namespace Eco.EM.Framework.Resolvers
                     newModels.Add(lModel);
             }
 
-            EMConfigurePlugin.Config.EMStorageSlots = newModels;
+            EMStorageSlotsPlugin.Config.EMStorageSlots = newModels;
 
             foreach (var model in newModels)
             {

--- a/Eco.EM.Framework/Resolvers/EMVehicleResolver.cs
+++ b/Eco.EM.Framework/Resolvers/EMVehicleResolver.cs
@@ -168,7 +168,7 @@ namespace Eco.EM.Framework.Resolvers
         public void Initialize()
         {
             SerializedSynchronizedCollection<VehicleModel> newModels = new();
-            var config = EMConfigurePlugin.Config.EMVehicles;
+            var config = EMVehiclesPlugin.Config.EMVehicles;
 
             foreach (var type in typeof(IConfigurableVehicle).ConcreteTypes())
             {
@@ -187,7 +187,7 @@ namespace Eco.EM.Framework.Resolvers
                     newModels.Add(lModel);
             }
 
-            EMConfigurePlugin.Config.EMVehicles = newModels;
+            EMVehiclesPlugin.Config.EMVehicles = newModels;
 
             foreach (var model in newModels)
             {


### PR DESCRIPTION
**Public Release Notes:**
- EMCustoms now has its own config in `Config/EMCustoms.eco`

**Additional Internal Details:**
- EMCustoms is now its own plugin and has separate build commands as the EMConfigure

**Teamwork**
Names of anyone who helped significantly with this PR:
- Existing code was used with minor edits by RainbowIris323

**In Response To:**
[https://github.com/TheKye/EM-Framework/pull/32#discussion_r1125940046](url)

